### PR TITLE
Slim down image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ WORKDIR /var/dynamodb_wd
 EXPOSE 8000
 
 # Get the package from Amazon
-RUN wget -O /var/dynamodb_wd/dynamodb_local_latest https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz
-RUN tar xfz /var/dynamodb_wd/dynamodb_local_latest
+RUN wget -O /tmp/dynamodb_local_latest https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz && \
+    tar xfz /tmp/dynamodb_local_latest && \
+    rm -f /tmp/dynamodb_local_latest
 
 # Default command for image
 ENTRYPOINT ["/usr/bin/java", "-Djava.library.path=.", "-jar", "DynamoDBLocal.jar", "-dbPath", "/var/dynamodb_local"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM makuk66/docker-oracle-java7
 MAINTAINER Dean Giberson <dean@deangiberson.com>
 
 # Create working space
-RUN mkdir /var/dynamodb_wd
 WORKDIR /var/dynamodb_wd
 
 # Default port for DynamoDB Local

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # https://aws.amazon.com/blogs/aws/dynamodb-local-for-desktop-development/
 #
-FROM makuk66/docker-oracle-java7
+FROM openjdk:7-jre
 MAINTAINER Dean Giberson <dean@deangiberson.com>
 
 # Create working space


### PR DESCRIPTION
I noticed the Dockerfile was leaving the downloaded `.tar.gz` file, which made the image a bit bigger than necessary.

Also I have updated the FROM line to a recent official build and removed an unnecessary `mkdir`.

Results: before:

    deangiberson/aws-dynamodb-local      latest     7ab9534fee30      4 weeks ago        613 MB

after:

    deangiberson/aws-dynamodb-local      latest     adcbc95e64ea      11 seconds ago     352 MB

I have tried the resulting image with my own Dyanmodb-using code, but no extensive testing.